### PR TITLE
Force bot-rerun for stsynphot 0.2.1

### DIFF
--- a/node_attrs/stsynphot.json
+++ b/node_attrs/stsynphot.json
@@ -58,7 +58,7 @@
     "__lazy_json__":"pr_json/356500987.json"
    },
    "data":{
-    "bot_rerun":false,
+    "bot_rerun":true,
     "migrator_name":"Version",
     "migrator_version":0,
     "version":"0.2.1"


### PR DESCRIPTION
This is like #4 but for `stsynphot`. I was waiting for the bot to rerun conda-forge/stsynphot-feedstock#5 but it never happened automatically in the "few hours" window that I was told is the time frame that it would happen. @CJ-Wright , can you please see if I am doing this correctly? Thank you!