### PR TITLE
Unmark pykerberos as archived in node_attrs

### DIFF
--- a/node_attrs/pykerberos.json
+++ b/node_attrs/pykerberos.json
@@ -1,5 +1,5 @@
 {
- "archived":true,
+ "archived":false,
  "bad":false,
  "conda-forge.yml":{},
  "feedstock_name":"pykerberos",


### PR DESCRIPTION
This PR marks `pykerberos` as `archived:false`.

cc @CJ-Wright 