### PR TITLE
Rebuild py38 migration for hangar-feedstock

### DIFF
--- a/node_attrs/hangar.json
+++ b/node_attrs/hangar.json
@@ -36,6 +36,25 @@
   },
   {
    "PR":{
+    "__lazy_json__":"pr_json/124039c9-3f22-4126-b5d1-6cfc674baaa6.json"
+   },
+   "data":{
+    "bot_rerun":1.0,
+    "migrator_name":"MigrationYaml",
+    "migrator_object_version":1,
+    "migrator_version":0,
+    "name":"python38"
+   },
+   "keys":[
+    "bot_rerun",
+    "migrator_name",
+    "migrator_object_version",
+    "migrator_version",
+    "name"
+   ]
+  },
+  {
+   "PR":{
     "__lazy_json__":"pr_json/398539745.json"
    },
    "data":{

--- a/node_attrs/hangar.json
+++ b/node_attrs/hangar.json
@@ -36,25 +36,6 @@
   },
   {
    "PR":{
-    "__lazy_json__":"pr_json/124039c9-3f22-4126-b5d1-6cfc674baaa6.json"
-   },
-   "data":{
-    "bot_rerun":false,
-    "migrator_name":"MigrationYaml",
-    "migrator_object_version":1,
-    "migrator_version":0,
-    "name":"python38"
-   },
-   "keys":[
-    "bot_rerun",
-    "migrator_name",
-    "migrator_object_version",
-    "migrator_version",
-    "name"
-   ]
-  },
-  {
-   "PR":{
     "__lazy_json__":"pr_json/398539745.json"
    },
    "data":{


### PR DESCRIPTION
Addresses bug in https://github.com/conda-forge/hangar-feedstock.

Submitting PR as advised by @CJ-Wright in https://github.com/regro/cf-scripts/issues/946