### PR TITLE
set mesa to unarchived

### DIFF
--- a/node_attrs/mesa.json
+++ b/node_attrs/mesa.json
@@ -1,5 +1,5 @@
 {
- "archived":true,
+ "archived":false,
  "bad":false,
  "conda-forge.yml":{},
  "feedstock_name":"mesa",


### PR DESCRIPTION
[mesa](https://github.com/conda-forge/mesa-feedstock) is alive.