### PR TITLE
Add new script for update version GSoC

### DIFF
--- a/update_version.py
+++ b/update_version.py
@@ -1,0 +1,59 @@
+from conda_forge_tick.utils import load_graph
+from conda_forge_tick.update_upstream_versions import (
+    get_latest_version,
+    PyPI,
+    CRAN,
+    NPM,
+    ROSDistro,
+    RawURL,
+    Github,
+)
+import random
+import json
+
+sources = (PyPI(), CRAN(), NPM(), ROSDistro(), RawURL(), Github())
+
+print("Reading graph")
+gx = load_graph()
+_all_nodes = [t for t in gx.nodes.items()]
+random.shuffle(_all_nodes)
+
+# Inspection the graph object and node update:
+print(f"Number of nodes: {len(gx.nodes)}")
+Node_count = 0
+to_update = {}
+to_update["nodes"] = []
+for node, node_attrs in _all_nodes:
+    # checking each node
+    with node_attrs["payload"] as attrs:
+        # verify the actual situation of the package;
+        actual_ver = str(attrs.get("version"))
+        if attrs.get("bad") or attrs.get("archived"):
+            print(
+                f"# {Node_count:<5} - {node:<30} - ver: {actual_ver:<10} - bad/archived"
+            )
+            Node_count += 1
+            continue
+        # New verison request
+        try:
+            new_version = get_latest_version(node, attrs, sources)
+        except Exception as e:
+            try:
+                se = repr(e)
+            except Exception as ee:
+                se = "Bad exception string: {}".format(ee)
+                print(f"Warning: Error getting upstream version of {node}: {se}")
+        if new_version == actual_ver:
+            # Not a good way to check this though...
+            Node_count += 1
+            continue 
+        else:
+            print(
+                f"# {Node_count:<5} - {node:<30} - ver: {attrs.get('version'):<10} - new ver: {new_version}"
+            )
+        to_update["nodes"].append({"id": str(node), "version": str(new_version)})
+    Node_count += 1
+
+# Writing  out file
+with open("new_version.json", "w") as outfile:
+    json.dump(to_update, outfile)


### PR DESCRIPTION
Includes the new attempt to a `update_version` function to work outside the main process (and directly on `cf-graph`). I am using only a simple scheme for the JSON output file, as we are giving a time with the DynamoDB stuff, and I added a simple (and not beautiful) option to discard any packages with current version as the latest available.

Ps: Sorry for the new branch `pull-requests` I wanted to use that as a different work space, but it didn't worked fine for me.