### PR TITLE
Remove pyepr-quantum PR's with wrong version

### DIFF
--- a/node_attrs/pyepr-quantum.json
+++ b/node_attrs/pyepr-quantum.json
@@ -16,40 +16,6 @@
     "migrator_version",
     "name"
    ]
-  },
-  {
-   "PR": {
-    "__lazy_json__": "pr_json/520246607.json"
-   },
-   "data": {
-    "bot_rerun": 1606921289.466189,
-    "migrator_name": "Version",
-    "migrator_version": 0,
-    "version": "8.4"
-   },
-   "keys": [
-    "bot_rerun",
-    "migrator_name",
-    "migrator_version",
-    "version"
-   ]
-  },
-  {
-   "PR": {
-    "__lazy_json__": "pr_json/531082208.json"
-   },
-   "data": {
-    "bot_rerun": false,
-    "migrator_name": "Version",
-    "migrator_version": 0,
-    "version": "8.4"
-   },
-   "keys": [
-    "bot_rerun",
-    "migrator_name",
-    "migrator_version",
-    "version"
-   ]
   }
  ],
  "archived": false,
@@ -206,10 +172,7 @@
   }
  },
  "name": "pyepr-quantum",
- "new_version": "8.4",
- "new_version_attempts": {
-  "8.4": 2
- },
+ "new_version": "0.8.4.3",
  "new_version_errors": {},
  "outputs_names": {
   "__set__": true,


### PR DESCRIPTION
The version was tagged upstream as 8.4 instead of 0.8.4 accidentally.
The bot's PR against the feedstock was closed, but it still prevents the
bot from making PR's for new versions less than 8.4.