### PR TITLE
Remove incomplete CUDA arch migrations

### DIFF
--- a/node_attrs/cudadecon.json
+++ b/node_attrs/cudadecon.json
@@ -113,25 +113,6 @@
     "migrator_version",
     "name"
    ]
-  },
-  {
-   "PR": {
-    "__lazy_json__": "pr_json/888292267.json"
-   },
-   "data": {
-    "bot_rerun": false,
-    "migrator_name": "MigrationYaml",
-    "migrator_object_version": 1,
-    "migrator_version": 0,
-    "name": "cuda_112_ppc64le_aarch64"
-   },
-   "keys": [
-    "bot_rerun",
-    "migrator_name",
-    "migrator_object_version",
-    "migrator_version",
-    "name"
-   ]
   }
  ],
  "archived": false,

--- a/node_attrs/hoomd.json
+++ b/node_attrs/hoomd.json
@@ -530,25 +530,6 @@
     "migrator_version",
     "name"
    ]
-  },
-  {
-   "PR": {
-    "__lazy_json__": "pr_json/888438594.json"
-   },
-   "data": {
-    "bot_rerun": false,
-    "migrator_name": "MigrationYaml",
-    "migrator_object_version": 1,
-    "migrator_version": 0,
-    "name": "cuda_112_ppc64le_aarch64"
-   },
-   "keys": [
-    "bot_rerun",
-    "migrator_name",
-    "migrator_object_version",
-    "migrator_version",
-    "name"
-   ]
   }
  ],
  "archived": false,

--- a/node_attrs/libastra.json
+++ b/node_attrs/libastra.json
@@ -56,25 +56,6 @@
     "migrator_version",
     "name"
    ]
-  },
-  {
-   "PR": {
-    "__lazy_json__": "pr_json/888293603.json"
-   },
-   "data": {
-    "bot_rerun": false,
-    "migrator_name": "MigrationYaml",
-    "migrator_object_version": 1,
-    "migrator_version": 0,
-    "name": "cuda_112_ppc64le_aarch64"
-   },
-   "keys": [
-    "bot_rerun",
-    "migrator_name",
-    "migrator_object_version",
-    "migrator_version",
-    "name"
-   ]
   }
  ],
  "archived": false,


### PR DESCRIPTION
These migrations are marked as completed since the CUDA arch migration PRs are merged. However they didn't undergo arch migrations first. Based on discussion in PR ( https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/2699 ), we decided to remove these migrations from here so they would not be treated as completed (since more work would be needed on them).

cc @isuruf