### PR TITLE
onednn: remove 3.0-pc

### DIFF
--- a/node_attrs/onednn.json
+++ b/node_attrs/onednn.json
@@ -670,23 +670,6 @@
     "migrator_version",
     "version"
    ]
-  },
-  {
-   "PR": {
-    "__lazy_json__": "pr_json/1158007040.json"
-   },
-   "data": {
-    "bot_rerun": false,
-    "migrator_name": "Version",
-    "migrator_version": 0,
-    "version": "3.0-pc"
-   },
-   "keys": [
-    "bot_rerun",
-    "migrator_name",
-    "migrator_version",
-    "version"
-   ]
   }
  ],
  "archived": false,
@@ -2185,7 +2168,7 @@
   }
  },
  "name": "onednn-split",
- "new_version": "3.0-pc",
+ "new_version": "2.7.2",
  "new_version_attempts": {
   "2.2": 1,
   "2.2.1": 1,
@@ -2211,8 +2194,7 @@
   "2.6.2": 1,
   "2.7": 1,
   "2.7.1": 1,
-  "2.7.2": 1,
-  "3.0-pc": 1
+  "2.7.2": 1
  },
  "new_version_errors": {},
  "osx_64_meta_yaml": {


### PR DESCRIPTION
3.0-pc is a preview candidate and is not an official release. The solution is to roll back the `new_version` of oneDNN to the previous one to catch 3.0 later. The issue is similar to https://github.com/regro/cf-scripts/issues/1550

cc @isuruf 