### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/import_to_pkg_maps/0/2/c/3/1/autogen.io.json
+++ b/import_to_pkg_maps/0/2/c/3/1/autogen.io.json
@@ -2,55 +2,55 @@
   "autogen.io": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.io.base": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.io.console": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.io.processors": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.io.processors.base": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.io.processors.console_event_processor": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.io.run_response": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.io.thread_io_stream": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.io.websockets": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   }
 }

--- a/import_to_pkg_maps/1/1/9/9/f/autogen.fa.json
+++ b/import_to_pkg_maps/1/1/9/9/f/autogen.fa.json
@@ -2,79 +2,79 @@
   "autogen.fast_depends": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.fast_depends._compat": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.fast_depends.core": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.fast_depends.core.build": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.fast_depends.core.model": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.fast_depends.dependencies": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.fast_depends.dependencies.model": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.fast_depends.dependencies.provider": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.fast_depends.library": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.fast_depends.library.model": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.fast_depends.schema": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.fast_depends.use": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.fast_depends.utils": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   }
 }

--- a/import_to_pkg_maps/1/e/5/8/8/autogen.ex.json
+++ b/import_to_pkg_maps/1/e/5/8/8/autogen.ex.json
@@ -2,13 +2,13 @@
   "autogen.exception_utils": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.extensions": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   }
 }

--- a/import_to_pkg_maps/9/7/b/7/b/autogen.ag.json
+++ b/import_to_pkg_maps/9/7/b/7/b/autogen.ag.json
@@ -2,679 +2,679 @@
   "autogen.agentchat": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.agent": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.assistant_agent": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.chat": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.contrib": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.contrib.agent_builder": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.contrib.agent_optimizer": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.contrib.capabilities": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.contrib.capabilities.agent_capability": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.contrib.capabilities.context_handling": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.contrib.capabilities.generate_images": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.contrib.capabilities.teachability": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.contrib.capabilities.text_compressors": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.contrib.capabilities.tools_capability": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.contrib.capabilities.transform_messages": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.contrib.capabilities.transforms": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.contrib.capabilities.transforms_util": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.contrib.capabilities.vision_capability": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.contrib.captainagent": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.contrib.captainagent.agent_builder": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.contrib.captainagent.captainagent": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.contrib.captainagent.tool_retriever": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.contrib.captainagent.tools": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.contrib.compressible_agent": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.contrib.gpt_assistant_agent": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.contrib.graph_rag": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.contrib.graph_rag.document": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.contrib.graph_rag.falkor_graph_query_engine": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.contrib.graph_rag.falkor_graph_rag_capability": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.contrib.graph_rag.graph_query_engine": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.contrib.graph_rag.graph_rag_capability": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.contrib.graph_rag.neo4j_graph_query_engine": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.contrib.graph_rag.neo4j_graph_rag_capability": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.contrib.graph_rag.neo4j_native_graph_query_engine": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.contrib.graph_rag.neo4j_native_graph_rag_capability": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.contrib.img_utils": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.contrib.llamaindex_conversable_agent": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.contrib.llava_agent": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.contrib.math_user_proxy_agent": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.contrib.multimodal_conversable_agent": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.contrib.qdrant_retrieve_user_proxy_agent": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.contrib.rag": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.contrib.rag.chromadb_query_engine": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.contrib.rag.llamaindex_query_engine": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.contrib.rag.mongodb_query_engine": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.contrib.rag.query_engine": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.contrib.retrieve_assistant_agent": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.contrib.retrieve_user_proxy_agent": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.contrib.society_of_mind_agent": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.contrib.swarm_agent": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.contrib.text_analyzer_agent": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.contrib.vectordb": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.contrib.vectordb.base": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.contrib.vectordb.chromadb": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.contrib.vectordb.couchbase": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.contrib.vectordb.mongodb": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.contrib.vectordb.pgvectordb": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.contrib.vectordb.qdrant": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.contrib.vectordb.utils": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.contrib.web_surfer": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.conversable_agent": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.groupchat": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.realtime": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.realtime.experimental": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.realtime.experimental.audio_adapters": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.realtime.experimental.audio_adapters.twilio_audio_adapter": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.realtime.experimental.audio_adapters.websocket_audio_adapter": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.realtime.experimental.audio_observer": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.realtime.experimental.clients": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.realtime.experimental.clients.gemini": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.realtime.experimental.clients.gemini.client": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.realtime.experimental.clients.oai": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.realtime.experimental.clients.oai.base_client": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.realtime.experimental.clients.oai.rtc_client": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.realtime.experimental.clients.oai.utils": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.realtime.experimental.clients.realtime_client": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.realtime.experimental.function_observer": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.realtime.experimental.realtime_agent": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.realtime.experimental.realtime_events": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.realtime.experimental.realtime_observer": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.realtime.experimental.realtime_swarm": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.realtime.experimental.websockets": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.realtime_agent": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.user_proxy_agent": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agentchat.utils": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agents": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agents.contrib": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agents.contrib.time": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agents.contrib.time.time_reply_agent": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agents.contrib.time.time_tool_agent": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agents.experimental": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agents.experimental.deep_research": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agents.experimental.deep_research.deep_research": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agents.experimental.discord": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agents.experimental.discord.discord": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agents.experimental.document_agent": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agents.experimental.document_agent.chroma_query_engine": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agents.experimental.document_agent.docling_doc_ingest_agent": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agents.experimental.document_agent.document_agent": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agents.experimental.document_agent.document_utils": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agents.experimental.document_agent.inmemory_query_engine": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agents.experimental.document_agent.parser_utils": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agents.experimental.document_agent.url_utils": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agents.experimental.reasoning": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agents.experimental.reasoning.reasoning_agent": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agents.experimental.slack": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agents.experimental.slack.slack": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agents.experimental.telegram": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agents.experimental.telegram.telegram": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agents.experimental.websurfer": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agents.experimental.websurfer.websurfer": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agents.experimental.wikipedia": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.agents.experimental.wikipedia.wikipedia": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   }
 }

--- a/import_to_pkg_maps/a/4/2/9/7/autogen.in.json
+++ b/import_to_pkg_maps/a/4/2/9/7/autogen.in.json
@@ -2,79 +2,79 @@
   "autogen.interop": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.interop.crewai": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.interop.crewai.crewai": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.interop.interoperability": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.interop.interoperable": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.interop.langchain": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.interop.langchain.langchain_chat_model_factory": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.interop.langchain.langchain_tool": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.interop.litellm": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.interop.litellm.litellm_config_factory": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.interop.pydantic_ai": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.interop.pydantic_ai.pydantic_ai": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.interop.registry": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   }
 }

--- a/import_to_pkg_maps/c/1/9/2/a/autogen.mc.json
+++ b/import_to_pkg_maps/c/1/9/2/a/autogen.mc.json
@@ -2,13 +2,13 @@
   "autogen.mcp": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.mcp.mcp_client": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   }
 }

--- a/import_to_pkg_maps/c/c/2/8/e/autogen.oa.json
+++ b/import_to_pkg_maps/c/c/2/8/e/autogen.oa.json
@@ -2,139 +2,139 @@
   "autogen.oai": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.oai.anthropic": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.oai.bedrock": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.oai.cerebras": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.oai.client": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.oai.client_utils": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.oai.cohere": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.oai.completion": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.oai.gemini": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.oai.gemini_types": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.oai.groq": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.oai.mistral": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.oai.oai_models": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.oai.oai_models._models": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.oai.oai_models.chat_completion": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.oai.oai_models.chat_completion_audio": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.oai.oai_models.chat_completion_message": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.oai.oai_models.chat_completion_message_tool_call": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.oai.oai_models.chat_completion_token_logprob": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.oai.oai_models.completion_usage": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.oai.ollama": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.oai.openai_utils": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.oai.together": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   }
 }

--- a/import_to_pkg_maps/d/2/d/1/3/autogen.to.json
+++ b/import_to_pkg_maps/d/2/d/1/3/autogen.to.json
@@ -2,253 +2,253 @@
   "autogen.token_count_utils": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.tools": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.tools.contrib": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.tools.contrib.time": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.tools.contrib.time.time": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.tools.dependency_injection": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.tools.experimental": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.tools.experimental.browser_use": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.tools.experimental.browser_use.browser_use": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.tools.experimental.crawl4ai": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.tools.experimental.crawl4ai.crawl4ai": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.tools.experimental.deep_research": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.tools.experimental.deep_research.deep_research": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.tools.experimental.google": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.tools.experimental.google.authentication": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.tools.experimental.google.authentication.credentials_hosted_provider": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.tools.experimental.google.authentication.credentials_local_provider": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.tools.experimental.google.authentication.credentials_provider": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.tools.experimental.google.drive": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.tools.experimental.google.drive.drive_functions": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.tools.experimental.google.drive.toolkit": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.tools.experimental.google.model": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.tools.experimental.google.toolkit_protocol": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.tools.experimental.google_search": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.tools.experimental.google_search.google_search": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.tools.experimental.google_search.youtube_search": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.tools.experimental.messageplatform": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.tools.experimental.messageplatform.discord": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.tools.experimental.messageplatform.discord.discord": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.tools.experimental.messageplatform.slack": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.tools.experimental.messageplatform.slack.slack": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.tools.experimental.messageplatform.telegram": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.tools.experimental.messageplatform.telegram.telegram": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.tools.experimental.perplexity": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.tools.experimental.perplexity.perplexity_search": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.tools.experimental.tavily": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.tools.experimental.tavily.tavily_search": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.tools.experimental.wikipedia": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.tools.experimental.wikipedia.wikipedia": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.tools.function_utils": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.tools.tool": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.tools.toolkit": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   }
 }

--- a/import_to_pkg_maps/f/c/8/2/3/autogen.co.json
+++ b/import_to_pkg_maps/f/c/8/2/3/autogen.co.json
@@ -2,103 +2,103 @@
   "autogen.code_utils": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.coding": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.coding.base": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.coding.docker_commandline_code_executor": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.coding.factory": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.coding.func_with_reqs": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.coding.jupyter": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.coding.jupyter.base": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.coding.jupyter.docker_jupyter_server": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.coding.jupyter.embedded_ipython_code_executor": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.coding.jupyter.import_utils": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.coding.jupyter.jupyter_client": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.coding.jupyter.jupyter_code_executor": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.coding.jupyter.local_jupyter_server": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.coding.local_commandline_code_executor": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.coding.markdown_code_extractor": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen.coding.utils": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   }
 }

--- a/import_to_pkg_maps/f/f/f/1/5/autogen._w.json
+++ b/import_to_pkg_maps/f/f/f/1/5/autogen._w.json
@@ -2,37 +2,37 @@
   "autogen._website": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen._website.generate_api_references": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen._website.generate_mkdocs": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen._website.notebook_processor": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen._website.process_notebooks": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "autogen._website.utils": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   }
 }

--- a/import_to_pkg_maps/import_to_pkg_maps_clobbering_pkgs.json
+++ b/import_to_pkg_maps/import_to_pkg_maps_clobbering_pkgs.json
@@ -3083,7 +3083,7 @@
     "pyasyncore",
     "pyathena",
     "pyaudio",
-    "pyautogen",
+    "ag2",
     "pyautogui",
     "pyb2d",
     "pybamm",

--- a/node_attrs/7/7/2/9/0/pyautogen.json
+++ b/node_attrs/7/7/2/9/0/pyautogen.json
@@ -15,7 +15,7 @@
       "tooling_branch_name": "main"
     }
   },
-  "feedstock_name": "pyautogen",
+  "feedstock_name": "ag2",
   "hash_type": "sha256",
   "linux_64_meta_yaml": {
     "about": {
@@ -38,7 +38,7 @@
       ]
     },
     "package": {
-      "name": "pyautogen",
+      "name": "ag2",
       "version": "0.9"
     },
     "requirements": {
@@ -69,7 +69,7 @@
     "schema_version": 0,
     "source": {
       "sha256": "58763009b6f6f988cdf9bb908c56a61a60c16e772096ab621edf06748fa58e50",
-      "url": "https://pypi.org/packages/source/p/pyautogen/pyautogen-0.9.tar.gz"
+      "url": "https://pypi.org/packages/source/p/ag2/ag2-0.9.tar.gz"
     },
     "test": {
       "commands": [
@@ -147,7 +147,7 @@
       ]
     },
     "package": {
-      "name": "pyautogen",
+      "name": "ag2",
       "version": "0.9"
     },
     "requirements": {
@@ -178,7 +178,7 @@
     "schema_version": 0,
     "source": {
       "sha256": "58763009b6f6f988cdf9bb908c56a61a60c16e772096ab621edf06748fa58e50",
-      "url": "https://pypi.org/packages/source/p/pyautogen/pyautogen-0.9.tar.gz"
+      "url": "https://pypi.org/packages/source/p/ag2/ag2-0.9.tar.gz"
     },
     "test": {
       "commands": [
@@ -193,11 +193,11 @@
       ]
     }
   },
-  "name": "pyautogen",
+  "name": "ag2",
   "outputs_names": {
     "__set__": true,
     "elements": [
-      "pyautogen"
+      "ag2"
     ]
   },
   "parsing_error": false,
@@ -205,9 +205,9 @@
     "linux_64"
   ],
   "pr_info": {
-    "__lazy_json__": "pr_info/pyautogen.json"
+    "__lazy_json__": "pr_info/ag2.json"
   },
-  "raw_meta_yaml": "{% set name = \"pyautogen\" %}\n{% set version = \"0.9\" %}\n\npackage:\n  name: {{ name|lower }}\n  version: {{ version }}\n\nsource:\n  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/pyautogen-{{ version }}.tar.gz\n  sha256: 58763009b6f6f988cdf9bb908c56a61a60c16e772096ab621edf06748fa58e50\n\nbuild:\n  noarch: python\n  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation\n  number: 0\n\nrequirements:\n  host:\n    - python {{ python_min }}\n    - hatchling\n    - pip\n  run:\n    - anyio >=3.0.0,<5.0.0\n    - httpx >=0.28.1,<1\n    - fast-depends >=2.4.12,<3\n    - asyncer ==0.0.8\n    - websockets >=14,<15\n    - python >={{ python_min }},<3.13\n    - openai >=1.58\n    - diskcache\n    - termcolor\n    - flaml\n    - numpy\n    - python-dotenv\n    - tiktoken\n    - pydantic >=2.6.1,<3\n    - docker-py\n    - packaging\n\ntest:\n  imports:\n    - autogen\n  commands:\n    - pip check\n  requires:\n    - pip\n    - python {{ python_min }}\n\nabout:\n  home: https://github.com/ag2ai/ag2\n  summary: A programming framework for agentic AI\n  license: Apache-2.0\n  license_file:\n    - NOTICE.md\n    - LICENSE\n\nextra:\n  recipe-maintainers:\n    - jan-janssen\n",
+  "raw_meta_yaml": "{% set name = \"ag2\" %}\n{% set version = \"0.9\" %}\n\npackage:\n  name: {{ name|lower }}\n  version: {{ version }}\n\nsource:\n  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/ag2-{{ version }}.tar.gz\n  sha256: 58763009b6f6f988cdf9bb908c56a61a60c16e772096ab621edf06748fa58e50\n\nbuild:\n  noarch: python\n  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation\n  number: 0\n\nrequirements:\n  host:\n    - python {{ python_min }}\n    - hatchling\n    - pip\n  run:\n    - anyio >=3.0.0,<5.0.0\n    - httpx >=0.28.1,<1\n    - fast-depends >=2.4.12,<3\n    - asyncer ==0.0.8\n    - websockets >=14,<15\n    - python >={{ python_min }},<3.13\n    - openai >=1.58\n    - diskcache\n    - termcolor\n    - flaml\n    - numpy\n    - python-dotenv\n    - tiktoken\n    - pydantic >=2.6.1,<3\n    - docker-py\n    - packaging\n\ntest:\n  imports:\n    - autogen\n  commands:\n    - pip check\n  requires:\n    - pip\n    - python {{ python_min }}\n\nabout:\n  home: https://github.com/ag2ai/ag2\n  summary: A programming framework for agentic AI\n  license: Apache-2.0\n  license_file:\n    - NOTICE.md\n    - LICENSE\n\nextra:\n  recipe-maintainers:\n    - jan-janssen\n",
   "req": {
     "__set__": true,
     "elements": [
@@ -316,9 +316,9 @@
       ]
     }
   },
-  "url": "https://pypi.org/packages/source/p/pyautogen/pyautogen-0.9.tar.gz",
+  "url": "https://pypi.org/packages/source/p/ag2/ag2-0.9.tar.gz",
   "version": "0.9",
   "version_pr_info": {
-    "__lazy_json__": "version_pr_info/pyautogen.json"
+    "__lazy_json__": "version_pr_info/ag2.json"
   }
 }


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using AG2! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
